### PR TITLE
bunch of fixes

### DIFF
--- a/BetterCoinflips/BetterCoinflips.csproj
+++ b/BetterCoinflips/BetterCoinflips.csproj
@@ -30,7 +30,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="ExMod.Exiled" Version="9.6.0" />
+    <PackageReference Include="ExMod.Exiled" Version="9.6.1" />
     <PackageReference Include="Lib.Harmony">
       <Version>2.2.2</Version>
     </PackageReference>

--- a/BetterCoinflips/Configs/Config.cs
+++ b/BetterCoinflips/Configs/Config.cs
@@ -192,7 +192,6 @@ namespace BetterCoinflips.Configs
             RoomType.HczHid,
             RoomType.HczNuke,
             RoomType.HczStraight,
-            RoomType.HczTesla,
             RoomType.HczTestRoom,
             RoomType.Lcz173,
             RoomType.Lcz330,

--- a/BetterCoinflips/Configs/Translations.cs
+++ b/BetterCoinflips/Configs/Translations.cs
@@ -59,7 +59,7 @@ namespace BetterCoinflips.Configs
         public string InventoryResetMessage { get; set; } = "You lost your stuff.";
         public string ClassSwapMessage { get; set; } = "That's what I call an UNO reverse card!";
         public string InstantExplosionMessage { get; set; } = "You got smoked.";
-        public string PlayerSwapMessage { get; set; } = "Your inventory was swapped with a random player.";
+        public string PlayerSwapMessage { get; set; } = "You were swapped with another player.";
         public string PlayerSwapIfOneAliveMessage { get; set; } = "You were supposed to switch places with someone but no one else is alive!";
         public string KickMessage { get; set; } = "Bye!";
         public string SpectSwapPlayerMessage { get; set; } = "You just made someone's round better!";

--- a/BetterCoinflips/Plugin.cs
+++ b/BetterCoinflips/Plugin.cs
@@ -8,8 +8,8 @@ namespace BetterCoinflips
 {
     public class Plugin : Plugin<Config, Configs.Translations>
     {
-        public override Version RequiredExiledVersion => new(9, 1, 1);
-        public override Version Version => new(5, 0, 0);
+        public override Version RequiredExiledVersion => new(9, 6, 0);
+        public override Version Version => new(5, 1, 0);
         public override string Author => "Miki_hero";
         public override string Name => "BetterCoinflips";
 

--- a/BetterCoinflips/Types/CoinEffect.cs
+++ b/BetterCoinflips/Types/CoinEffect.cs
@@ -98,7 +98,7 @@ namespace BetterCoinflips.Types
             new CoinFlipEffect(Translations.OneAmmoLogicerMessage, player =>
             {
                 Firearm gun = (Firearm)Item.Create(ItemType.GunLogicer);
-                gun.BarrelAmmo = 1;
+                gun.MagazineAmmo = 1;
                 gun.CreatePickup(player.Position);
             }),
 
@@ -122,6 +122,7 @@ namespace BetterCoinflips.Types
                 Firearm revo = (Firearm)Item.Create(ItemType.GunRevolver);
                 revo.AddAttachment(new[]
                     {AttachmentName.CylinderMag7, AttachmentName.ShortBarrel, AttachmentName.ScopeSight});
+                revo.MagazineAmmo = revo.MaxMagazineAmmo;
                 revo.CreatePickup(player.Position);
             }),
 
@@ -149,7 +150,13 @@ namespace BetterCoinflips.Types
             // 14: Spawns a random item for the player.
             new CoinFlipEffect(Translations.RandomItemMessage, player =>
             {
-                Item.Create(Config.ItemsToGive.ToList().RandomItem()).CreatePickup(player.Position);
+                var itemType = Config.ItemsToGive.ToList().RandomItem();
+                var item = Item.Create(itemType);
+
+                if (item is Firearm firearm)
+                    firearm.MagazineAmmo = firearm.MaxMagazineAmmo;
+
+                item.CreatePickup(player.Position);
             }),
         };
 
@@ -409,9 +416,9 @@ namespace BetterCoinflips.Types
             new CoinFlipEffect(Warhead.IsDetonated ? Translations.TeslaTpAfterWarheadMessage : Translations.TeslaTpMessage, player =>
             {
                 player.DropHeldItem();
-                
-                player.Teleport(Exiled.API.Features.TeslaGate.List.ToList().RandomItem());
-                
+
+                player.Teleport(Room.Get(r => r.Type == RoomType.HczTesla).GetRandomValue());
+
                 if (Warhead.IsDetonated)
                 {
                     player.Kill(DamageType.Decontamination);


### PR DESCRIPTION
1. Updated Exiled version
2. Updated plugin version
3. Removed HczTesla from rooms_to_teleport (because tesla_tp exist)
4. Fixed Logicer with one ammo
5. Fixed guns from items_to_give spawning without ammo
6. Fixed Bad Revolver spawning without ammo
7. Fixed tesla_tp teleporting players into walls
8. Incorrect PlayerSwap translation